### PR TITLE
improve parse exceptions with line and column nr and token value

### DIFF
--- a/src/main/java/org/nobloat/bare/dsl/AstParser.java
+++ b/src/main/java/org/nobloat/bare/dsl/AstParser.java
@@ -61,19 +61,19 @@ public class AstParser {
                 return parseUserEnum();
         }
 
-        throw new IllegalStateException(String.format("Unexpected token %s. Required: 'type' or 'enum'", token.type));
+        throw unexpectedTokenException(token, "'type' or 'enum'");
     }
 
     private  Ast.UserDefinedType parseUserType() throws IOException {
         Lexer.Token nameToken = lexer.nextToken();
 
         if (nameToken.type != Lexer.Token.Type.NAME) {
-            throw new IllegalStateException(String.format("Unexpected token %s. Required: type 'name'", nameToken.type));
+            throw unexpectedTokenException(nameToken, "type 'name'");
         }
 
         Matcher matcher = USER_TYPE_NAME_RE.matcher(nameToken.value);
         if (!matcher.matches()) {
-            throw new IllegalStateException(String.format("Invalid name for user type %s. Must match: %s", nameToken.type, USER_TYPE_NAME_RE.pattern()));
+            throw illegalNameException(nameToken, USER_TYPE_NAME_RE);
         }
 
         Ast.Type type = parseType();
@@ -131,14 +131,14 @@ public class AstParser {
                 return new Ast.NamedUserType(token.value);
         }
 
-        throw new IllegalStateException(String.format("Unexpected token %s. Required: type ", token.type));
+        throw unexpectedTokenException(token, "type");
     }
 
     private Ast.OptionalType parseOptionalType() throws IOException {
         Lexer.Token leftAngle = lexer.nextToken();
 
         if (leftAngle.type != Lexer.Token.Type.L_ANGLE) {
-            throw new IllegalStateException(String.format("Unexpected token %s. Required: '<'", leftAngle.type));
+            throw unexpectedTokenException(leftAngle, "'<'");
         }
 
         Ast.Type subType = parseType();
@@ -146,7 +146,7 @@ public class AstParser {
         Lexer.Token rightAngle = lexer.nextToken();
 
         if (rightAngle.type != Lexer.Token.Type.R_ANGLE) {
-            throw new IllegalStateException(String.format("Unexpected token %s. Required: '>'", rightAngle.type));
+            throw unexpectedTokenException(rightAngle, "'>'");
         }
 
         return new Ast.OptionalType(subType);
@@ -163,7 +163,7 @@ public class AstParser {
         Lexer.Token number = lexer.nextToken();
 
         if (number.type != Lexer.Token.Type.NUMBER) {
-            throw new IllegalStateException(String.format("Unexpected token %s. Required: 'integer'", number.type));
+            throw unexpectedTokenException(number, "'number'");
         }
 
         int length = Integer.parseInt(number.value);
@@ -171,7 +171,7 @@ public class AstParser {
         Lexer.Token rightAngle = lexer.nextToken();
 
         if (rightAngle.type != Lexer.Token.Type.R_ANGLE) {
-            throw new IllegalStateException(String.format("Unexpected token %s. Required: '>'", rightAngle.type));
+            throw unexpectedTokenException(rightAngle, "'>'");
         }
 
         return new Ast.DataType(length);
@@ -182,7 +182,7 @@ public class AstParser {
         Lexer.Token leftBracket = lexer.nextToken();
 
         if (leftBracket.type != Lexer.Token.Type.L_BRACKET) {
-            throw new IllegalStateException(String.format("Unexpected token %s. Required: '['", leftBracket.type));
+            throw unexpectedTokenException(leftBracket, "'['");
         }
 
         Ast.Type keyType = parseType();
@@ -190,7 +190,7 @@ public class AstParser {
         Lexer.Token rightBracket = lexer.nextToken();
 
         if (rightBracket.type != Lexer.Token.Type.R_BRACKET) {
-            throw new IllegalStateException(String.format("Unexpected token %s. Required: ']'", rightBracket.type));
+            throw unexpectedTokenException(rightBracket, "']'");
         }
 
         Ast.Type valueType = parseType();
@@ -209,13 +209,13 @@ public class AstParser {
                 Lexer.Token rightBracket = lexer.nextToken();
 
                 if (rightBracket.type != Lexer.Token.Type.R_BRACKET) {
-                    throw new IllegalStateException(String.format("Unexpected token %s. Required: ']'", token.type));
+                    throw unexpectedTokenException(rightBracket, "']'");
                 }
                 break;
             case R_BRACKET:
                 break;
             default:
-                throw new IllegalStateException(String.format("Unexpected token %s. Required: ']'", token.type));
+                throw unexpectedTokenException(token, "']'");
         }
 
 
@@ -237,7 +237,7 @@ public class AstParser {
 
                 Lexer.Token number = lexer.nextToken();
                 if (number.type != Lexer.Token.Type.NUMBER) {
-                    throw new IllegalStateException(String.format("Unexpected token %s. Required: 'number'", token.type));
+                    throw unexpectedTokenException(token, "'number'");
                 }
 
                 tag = Integer.parseInt(number.value);
@@ -255,7 +255,7 @@ public class AstParser {
             } else if (nextToken.type == Lexer.Token.Type.R_PAREN) {
                 break;
             } else {
-                throw new IllegalStateException(String.format("Unexpected token %s. Required: '|' or ')'", token.type));
+                throw unexpectedTokenException(token, "'|' or ')'");
             }
         }
 
@@ -272,18 +272,18 @@ public class AstParser {
                 break;
             }
             if (token.type != Lexer.Token.Type.NAME) {
-                throw new IllegalStateException(String.format("Unexpected token %s. Required: field name", token.type));
+                throw unexpectedTokenException(token, "field name");
             }
 
             String name = token.value;
             Matcher matcher = FIELD_NAME_RE.matcher(name);
             if (!matcher.matches()) {
-                throw new IllegalStateException(String.format("Invalid name for field %s. Must match: %s", name, FIELD_NAME_RE.pattern()));
+                throw illegalNameException(token, FIELD_NAME_RE);
             }
 
             Lexer.Token colon = lexer.nextToken();
             if (colon.type != Lexer.Token.Type.COLON) {
-                throw new IllegalStateException(String.format("Unexpected token %s. Required: ':'", colon.type));
+                throw unexpectedTokenException(colon, "':'");
             }
 
             Ast.Type type = parseType();
@@ -298,7 +298,7 @@ public class AstParser {
 
         Lexer.Token name = lexer.nextToken();
         if (name.type != Lexer.Token.Type.NAME) {
-            throw new IllegalStateException(String.format("Unexpected token %s. Required: enum name", name.type));
+            throw unexpectedTokenException(name, "enum 'name'");
         }
 
         Lexer.Token token = lexer.nextToken();
@@ -324,7 +324,7 @@ public class AstParser {
 
         Lexer.Token leftBrace = lexer.nextToken();
         if (leftBrace.type != Lexer.Token.Type.L_BRACE) {
-            throw new IllegalStateException(String.format("Unexpected token %s. Required: '{'", leftBrace.type));
+            throw unexpectedTokenException(leftBrace, "'{'");
         }
 
         int value = 0;
@@ -332,13 +332,13 @@ public class AstParser {
         while (true) {
             Lexer.Token valueNameToken = lexer.nextToken();
             if (valueNameToken.type != Lexer.Token.Type.NAME) {
-                throw new IllegalStateException(String.format("Unexpected token %s. Required: value name", valueNameToken.type));
+                throw unexpectedTokenException(valueNameToken, "value 'name'");
             }
 
             String valueName = valueNameToken.value;
             Matcher matcher = ENUM_VALUE_RE.matcher(valueName);
             if (!matcher.matches()) {
-                throw new IllegalStateException(String.format("Invalid name for enum value %s. Must match: %s", valueNameToken.type, ENUM_VALUE_RE.pattern()));
+                throw illegalNameException(valueNameToken, ENUM_VALUE_RE);
             }
 
             int evValue;
@@ -346,7 +346,7 @@ public class AstParser {
             if (nextToken.type == Lexer.Token.Type.EQUAL) {
                 Lexer.Token number = lexer.nextToken();
                 if (number.type != Lexer.Token.Type.NUMBER) {
-                    throw new IllegalStateException(String.format("Unexpected token %s. Required: number", number.type));
+                    throw unexpectedTokenException(number, "'number'");
                 }
 
                 value = Integer.parseInt(number.value);
@@ -366,15 +366,23 @@ public class AstParser {
             } else if (nextToken2.type == Lexer.Token.Type.NAME) {
                 lexer.pushback(nextToken2);
             } else {
-                throw new IllegalStateException(String.format("Unexpected token %s. Required: 'value name'", nextToken2.type));
+                throw unexpectedTokenException(nextToken2, "value 'name'");
             }
         }
 
         Matcher matcher = USER_ENUM_NAME_RE.matcher(name.value);
         if (!matcher.matches()) {
-            throw new IllegalStateException(String.format("Invalid name for user enum %s. Must match: %s", name.type, USER_ENUM_NAME_RE.pattern()));
+            throw new IllegalStateException(String.format("Line: %s - Invalid name for user enum %s. Must match: %s", name.lineNumber, name.type, USER_ENUM_NAME_RE.pattern()));
         }
 
         return new Ast.UserDefinedEnum(name.value, kind, values);
+    }
+
+    private IllegalStateException unexpectedTokenException(Lexer.Token token, String requiredMessage) {
+        return new IllegalStateException(String.format("(%s:%s) - Unexpected token '%s'. Required: %s", token.lineNumber, token.column, token.value, requiredMessage));
+    }
+
+    private IllegalStateException illegalNameException(Lexer.Token token, Pattern pattern) {
+        return new IllegalStateException(String.format("(%s:%s) - Invalid name '%s'. Must match: %s", token.lineNumber, token.column, token.value, pattern.pattern()));
     }
 }

--- a/src/main/java/org/nobloat/bare/dsl/Lexer.java
+++ b/src/main/java/org/nobloat/bare/dsl/Lexer.java
@@ -26,7 +26,7 @@ public class Lexer {
         } while (Character.isSpaceChar((char) ch) || scanner.isNewLine((char) ch));
 
         if (ch == -1) {
-            return new Token(Token.Type.EOF);
+            return new Token(Token.Type.EOF, "EOF", scanner.getLineNumber(), scanner.getColumn());
         }
 
         char character = (char) ch;
@@ -40,7 +40,7 @@ public class Lexer {
         if (Character.isDigit(character)) {
             scanner.unreadChar();
             String integer = scanner.readInteger();
-            return new Token(Token.Type.NUMBER, integer);
+            return new Token(Token.Type.NUMBER, integer, scanner.getLineNumber(), scanner.getColumn());
         }
 
         switch (character) {
@@ -49,30 +49,30 @@ public class Lexer {
 //                return new Token(Token.Type.COMMENT, comment);
                 return nextToken();
             case '<':
-                return new Token(Token.Type.L_ANGLE);
+                return new Token(Token.Type.L_ANGLE, character, scanner.getLineNumber(), scanner.getColumn());
             case '>':
-                return new Token(Token.Type.R_ANGLE);
+                return new Token(Token.Type.R_ANGLE, character, scanner.getLineNumber(), scanner.getColumn());
             case '{':
-                return new Token(Token.Type.L_BRACE);
+                return new Token(Token.Type.L_BRACE, character, scanner.getLineNumber(), scanner.getColumn());
             case '}':
-                return new Token(Token.Type.R_BRACE);
+                return new Token(Token.Type.R_BRACE, character, scanner.getLineNumber(), scanner.getColumn());
             case '[':
-                return new Token(Token.Type.L_BRACKET);
+                return new Token(Token.Type.L_BRACKET, character, scanner.getLineNumber(), scanner.getColumn());
             case ']':
-                return new Token(Token.Type.R_BRACKET);
+                return new Token(Token.Type.R_BRACKET, character, scanner.getLineNumber(), scanner.getColumn());
             case '(':
-                return new Token(Token.Type.L_PAREN);
+                return new Token(Token.Type.L_PAREN, character, scanner.getLineNumber(), scanner.getColumn());
             case ')':
-                return new Token(Token.Type.R_PAREN);
+                return new Token(Token.Type.R_PAREN, character, scanner.getLineNumber(), scanner.getColumn());
             case '|':
-                return new Token(Token.Type.PIPE);
+                return new Token(Token.Type.PIPE, character, scanner.getLineNumber(), scanner.getColumn());
             case '=':
-                return new Token(Token.Type.EQUAL);
+                return new Token(Token.Type.EQUAL, character, scanner.getLineNumber(), scanner.getColumn());
             case ':':
-                return new Token(Token.Type.COLON);
+                return new Token(Token.Type.COLON, character, scanner.getLineNumber(), scanner.getColumn());
         }
 
-        return new Token(Token.Type.UNKNOWN);
+        return new Token(Token.Type.UNKNOWN, character, scanner.getLineNumber(), scanner.getColumn());
     }
 
     public void pushback(Token token) {
@@ -83,62 +83,66 @@ public class Lexer {
 
         switch (word) {
             case "type":
-                return new Token(Token.Type.TYPE);
+                return new Token(Token.Type.TYPE, word, scanner.getLineNumber(), scanner.getColumn());
             case "enum":
-                return new Token(Token.Type.ENUM);
+                return new Token(Token.Type.ENUM, word, scanner.getLineNumber(), scanner.getColumn());
             case "uint":
-                return new Token(Token.Type.UINT);
+                return new Token(Token.Type.UINT, word, scanner.getLineNumber(), scanner.getColumn());
             case "u8":
-                return new Token(Token.Type.U8);
+                return new Token(Token.Type.U8, word, scanner.getLineNumber(), scanner.getColumn());
             case "u16":
-                return new Token(Token.Type.U16);
+                return new Token(Token.Type.U16, word, scanner.getLineNumber(), scanner.getColumn());
             case "u32":
-                return new Token(Token.Type.U32);
+                return new Token(Token.Type.U32, word, scanner.getLineNumber(), scanner.getColumn());
             case "u64":
-                return new Token(Token.Type.U64);
+                return new Token(Token.Type.U64, word, scanner.getLineNumber(), scanner.getColumn());
             case "int":
-                return new Token(Token.Type.INT);
+                return new Token(Token.Type.INT, word, scanner.getLineNumber(), scanner.getColumn());
             case "i8":
-                return new Token(Token.Type.I8);
+                return new Token(Token.Type.I8, word, scanner.getLineNumber(), scanner.getColumn());
             case "i16":
-                return new Token(Token.Type.I16);
+                return new Token(Token.Type.I16, word, scanner.getLineNumber(), scanner.getColumn());
             case "i32":
-                return new Token(Token.Type.I32);
+                return new Token(Token.Type.I32, word, scanner.getLineNumber(), scanner.getColumn());
             case "i64":
-                return new Token(Token.Type.I64);
+                return new Token(Token.Type.I64, word, scanner.getLineNumber(), scanner.getColumn());
             case "f32":
-                return new Token(Token.Type.F32);
+                return new Token(Token.Type.F32, word, scanner.getLineNumber(), scanner.getColumn());
             case "f64":
-                return new Token(Token.Type.F64);
+                return new Token(Token.Type.F64, word, scanner.getLineNumber(), scanner.getColumn());
             case "bool":
-                return new Token(Token.Type.BOOL);
+                return new Token(Token.Type.BOOL, word, scanner.getLineNumber(), scanner.getColumn());
             case "string":
-                return new Token(Token.Type.STRING);
+                return new Token(Token.Type.STRING, word, scanner.getLineNumber(), scanner.getColumn());
             case "data":
-                return new Token(Token.Type.DATA);
+                return new Token(Token.Type.DATA, word, scanner.getLineNumber(), scanner.getColumn());
             case "void":
-                return new Token(Token.Type.VOID);
+                return new Token(Token.Type.VOID, word, scanner.getLineNumber(), scanner.getColumn());
             case "optional":
-                return new Token(Token.Type.OPTIONAL);
+                return new Token(Token.Type.OPTIONAL, word, scanner.getLineNumber(), scanner.getColumn());
             case "map":
-                return new Token(Token.Type.MAP);
+                return new Token(Token.Type.MAP, word, scanner.getLineNumber(), scanner.getColumn());
         }
 
-        return new Token(Token.Type.NAME, word);
+        return new Token(Token.Type.NAME, word, scanner.getLineNumber(), scanner.getColumn());
     }
 
     public static class Token {
 
         final Type type;
         final String value;
+        final int lineNumber;
+        final int column;
 
-        public Token(Type type) {
-            this(type, null);
+        public Token(Type type, char value, int lineNumber, int column) {
+            this(type, Character.toString(value), lineNumber, column);
         }
 
-        public Token(Type type, String value) {
+        public Token(Type type, String value, int lineNumber, int column) {
             this.type = type;
             this.value = value;
+            this.lineNumber = lineNumber;
+            this.column = column;
         }
 
         enum Type {

--- a/src/main/java/org/nobloat/bare/dsl/PositionTracker.java
+++ b/src/main/java/org/nobloat/bare/dsl/PositionTracker.java
@@ -1,0 +1,38 @@
+package org.nobloat.bare.dsl;
+
+public class PositionTracker {
+
+    private int line = 1;
+    private int column = 0;
+    private int previousColumn = 0;
+    private char lastCharacter;
+
+    public void nextCharacter(int read) {
+        lastCharacter = (char) read;
+
+        column++;
+
+        if (lastCharacter == '\n') {
+            line++;
+            previousColumn = column;
+            column = 0;
+        }
+    }
+
+    public void withdrawLastCharacter() {
+        if (lastCharacter == '\n') {
+            line--;
+            column = previousColumn;
+        } else {
+            column--;
+        }
+    }
+
+    public int getLine() {
+        return line;
+    }
+
+    public int getColumn() {
+        return column;
+    }
+}

--- a/src/main/java/org/nobloat/bare/dsl/Scanner.java
+++ b/src/main/java/org/nobloat/bare/dsl/Scanner.java
@@ -7,18 +7,26 @@ import java.io.InputStream;
 public class Scanner implements AutoCloseable {
 
     private final BufferedInputStream reader;
+    private final PositionTracker positionTracker;
 
     public Scanner(InputStream is) {
         reader = new BufferedInputStream(is, 2);
+        positionTracker = new PositionTracker();
     }
 
     public int readChar() throws IOException {
         reader.mark(1);
-        return reader.read();
+        int read = reader.read();
+
+        positionTracker.nextCharacter(read);
+
+        return read;
     }
 
     public void unreadChar() throws IOException {
         reader.reset();
+
+        positionTracker.withdrawLastCharacter();
     }
 
     public String readInteger() throws IOException {
@@ -40,7 +48,7 @@ public class Scanner implements AutoCloseable {
             builder.append(character);
         }
 
-        if(builder.length() == 0) {
+        if (builder.length() == 0) {
             throw new IOException("Is not an integer");
         }
 
@@ -66,7 +74,7 @@ public class Scanner implements AutoCloseable {
             builder.append(character);
         }
 
-        if(builder.length() == 0) {
+        if (builder.length() == 0) {
             throw new IOException("Is not a word");
         }
 
@@ -97,6 +105,14 @@ public class Scanner implements AutoCloseable {
 
     public boolean isNewLine(char character) {
         return character == '\n' || character == '\r';
+    }
+
+    public int getLineNumber() {
+        return positionTracker.getLine();
+    }
+
+    public int getColumn() {
+        return positionTracker.getColumn();
     }
 
     public void close() throws Exception {

--- a/src/test/java/org/nobloat/bare/dsl/AstParserTest.java
+++ b/src/test/java/org/nobloat/bare/dsl/AstParserTest.java
@@ -114,6 +114,49 @@ public class AstParserTest {
         }
     }
 
+    @Test
+    public void shouldThrowExceptionWhenInvalidTokenIsFound() throws Exception {
+        String input = "type Customer {\n" +
+                "  name: string\n" +
+                "  metadata: asdf[string]data\n" +
+                "}";
+
+        try (InputStream is = toStream(input);
+             Scanner scanner = new Scanner(is)) {
+            Lexer lexer = new Lexer(scanner);
+            AstParser astParser = new AstParser(lexer);
+
+            try {
+                astParser.parse();
+            } catch (IllegalStateException ex) {
+                assertEquals("(3:17) - Unexpected token '['. Required: field name", ex.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenInvalidTokenIsFound2() throws Exception {
+        String input = "type Customer {\n" +
+                "  address: Address\n" +
+                "  orders: [{\n" +
+                "    orderId: i64\n" +
+                "    quantity: i32\n" +
+                "  }\n" +
+                "}";
+
+        try (InputStream is = toStream(input);
+             Scanner scanner = new Scanner(is)) {
+            Lexer lexer = new Lexer(scanner);
+            AstParser astParser = new AstParser(lexer);
+
+            try {
+                astParser.parse();
+            } catch (IllegalStateException ex) {
+                assertEquals("(3:12) - Unexpected token '{'. Required: ']'", ex.getMessage());
+            }
+        }
+    }
+
     private InputStream toStream(String input) {
         return new ByteArrayInputStream(input.getBytes());
     }


### PR DESCRIPTION
For example:

(3:12) - Unexpected token '{'. Required: ']'